### PR TITLE
Add firefox build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 !dist/icon.png
 !dist/manifest.json
+web-ext-artifacts/

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "webpack"
+    "build": "webpack",
+    "build:firefox": "web-ext build -s dist/ -o"
   },
   "author": "",
   "license": "ISC",
@@ -19,5 +20,8 @@
     "react-dom": "16.0.0",
     "react-syntax-highlighter": "5.7.0",
     "webpack": "3.6.0"
+  },
+  "devDependencies": {
+    "web-ext": "^2.2.0"
   }
 }


### PR DESCRIPTION
This adds a script which enables you to build for firefox.

All you need to do is to run `npm run build:firefox` to build the release archive which can be uploaded to https://addons.mozilla.org.